### PR TITLE
Removed check for new pinch interface.

### DIFF
--- a/telemetry/telemetry/internal/actions/pinch.py
+++ b/telemetry/telemetry/internal/actions/pinch.py
@@ -37,12 +37,6 @@ class PinchAction(page_action.PageAction):
       raise page_action.PageActionNotSupported(
           'Synthetic pinch not supported for this browser')
 
-    # TODO(dominikg): Remove once JS interface changes have rolled into stable.
-    if not tab.EvaluateJavaScript('chrome.gpuBenchmarking.newPinchInterface'):
-      raise page_action.PageActionNotSupported(
-          'This version of the browser doesn\'t support the new JS interface '
-          'for pinch gestures.')
-
     done_callback = 'function() { window.__pinchActionDone = true; }'
     tab.ExecuteJavaScript("""
         window.__pinchActionDone = false;


### PR DESCRIPTION
This was added in https://chromium.googlesource.com/chromium/src/+/33963436e74bd0adca3be5f3a7a56dc9c25fc434 back in 2014 so it should be fine to remove now.

Associated removal in Chromium: https://codereview.chromium.org/1671413002/