### PR TITLE
Adds contains/equals stub methods to Frame.

### DIFF
--- a/tracing/tracing/model/frame.html
+++ b/tracing/tracing/model/frame.html
@@ -78,6 +78,14 @@ tr.exportTo('tr.model', function() {
     addBoundsToRange: function(range) {
       range.addValue(this.start);
       range.addValue(this.end);
+    },
+
+    contains: function() {
+      return false;
+    },
+
+    equals: function(that) {
+      return this === that;
     }
   };
 


### PR DESCRIPTION
Trace viewing of Android traces seems to stop working for me after certain
selection changes involving frames, and the console starts complaining about the
selection on analysis-link not having contains and/or equals. From
debugging it seems like this typically expects an EventSet, which
implements contains/equals. I have very limited knowledge of this
codebase, so please let me know if there's a better way to seal off this
error.