### PR TITLE
Fix loss of frequency residency stats

### DIFF
--- a/telemetry/telemetry/internal/platform/power_monitor/sysfs_power_monitor.py
+++ b/telemetry/telemetry/internal/platform/power_monitor/sysfs_power_monitor.py
@@ -77,7 +77,7 @@ class SysfsPowerMonitor(power_monitor.PowerMonitor):
             self._platform.ParseCStateSample(self._final_cstate))
         for cpu in frequencies:
           out[cpu] = {'frequency_percent': frequencies.get(cpu)}
-          out[cpu] = {'cstate_residency_percent': cstates.get(cpu)}
+          out[cpu].update({'cstate_residency_percent': cstates.get(cpu)})
       if self._standalone:
         return self.CombineResults(out, {})
       return out


### PR DESCRIPTION
A bug in the processing of power data results in losing the frequency residency information. Fix this issue.