### PR TITLE
Fix stack trace symbolization on Windows.

### DIFF
--- a/telemetry/telemetry/internal/binary_dependencies.json
+++ b/telemetry/telemetry/internal/binary_dependencies.json
@@ -51,16 +51,6 @@
         }
       }
     },
-    "crash_service": {
-      "cloud_storage_base_folder": "binary_dependencies",
-      "cloud_storage_bucket": "chromium-telemetry",
-      "file_info": {
-        "win_AMD64": {
-          "cloud_storage_hash": "4a0961e972895f4af3b7cfab959c5bfd4de7174b",
-          "download_path": "bin/win/AMD64/crash_service.exe"
-        }
-      }
-    },
     "determine_if_keychain_entry_is_decryptable": {
       "cloud_storage_base_folder": "binary_dependencies",
       "cloud_storage_bucket": "chromium-telemetry",

--- a/telemetry/telemetry/internal/util/path.py
+++ b/telemetry/telemetry/internal/util/path.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import glob
 import os
 
 from telemetry.core import util
@@ -17,6 +18,11 @@ GetBuildDirectories = util.GetBuildDirectories
 IsExecutable = catapult_util.IsExecutable
 
 
+def _HasWildcardCharacters(input_string):
+  # Could make this more precise.
+  return '*' in input_string or '+' in input_string
+
+
 def FindInstalledWindowsApplication(application_path):
   """Search common Windows installation directories for an application.
 
@@ -29,14 +35,17 @@ def FindInstalledWindowsApplication(application_path):
                   os.getenv('PROGRAMFILES'),
                   os.getenv('LOCALAPPDATA')]
   search_paths += os.getenv('PATH', '').split(os.pathsep)
-
   for search_path in search_paths:
     if not search_path:
       continue
     path = os.path.join(search_path, application_path)
-    if IsExecutable(path):
-      return path
-
+    if _HasWildcardCharacters(path):
+      paths = glob.glob(path)
+    else:
+      paths = [ path ]
+    for p in paths:
+      if IsExecutable(p):
+        return p
   return None
 
 

--- a/telemetry/telemetry/internal/util/path_unittest.py
+++ b/telemetry/telemetry/internal/util/path_unittest.py
@@ -19,3 +19,8 @@ class PathTest(unittest.TestCase):
   def testFindInstalledWindowsApplication(self):
     self.assertTrue(path.FindInstalledWindowsApplication(os.path.join(
         'Internet Explorer', 'iexplore.exe')))
+
+  @decorators.Enabled('win')
+  def testFindInstalledWindowsApplicationWithWildcards(self):
+    self.assertTrue(path.FindInstalledWindowsApplication(os.path.join(
+        '*', 'iexplore.exe')))


### PR DESCRIPTION
(Joint work with @DavidYen)

This CL requires a companion Chromium CL in order to fix stack trace
symbolization on Windows. It makes the following changes:

 - The Windows toolchain installed on the bots and for Chromium
   developers is now versioned by hash. It's impractical to parse the
   hashes, since doing so would add another strong tie between the
   Catapult and Chromium workspaces, so instead support wildcards in
   Telemetry's path utilities for finding cdb.exe. (Any version of
   this tool will work.)

 - It deletes code associated with the obsolete crash_service.
   Chromium on Windows now uses Crashpad.

 - It relies on Crashpad to honor the BREAKPAD_DUMP_LOCATION
   environment variable. (This requires a Chromium change.)

Once this CL is rolled into Chromium, tools/perf's stack trace
unittest will be enabled on Windows, preventing this functionality
from regressing again.

BUG=chromium:561763