### PR TITLE
Fix unused-result warning with GN

### DIFF
--- a/telemetry/BUILD.gn
+++ b/telemetry/BUILD.gn
@@ -19,4 +19,6 @@ executable("bitmaptools") {
   deps = [
     "//build/config/sanitizers:deps",
   ]
+  
+  cflags = [ "-Wno-unused-result" ]
 }


### PR DESCRIPTION
See issue #2297