### PR TITLE
Trimmed unneeded code per issue 2283.

### DIFF
--- a/dashboard/dashboard/start_try_job.py
+++ b/dashboard/dashboard/start_try_job.py
@@ -442,8 +442,6 @@ def _GuessCommandTelemetry(
   # TODO(qyearsley): Use metric to add a --story-filter flag for Telemetry.
   # See: http://crbug.com/448628
   command = []
-  if bisect_bot.startswith('win'):
-    command.append('python')
 
   if use_buildbucket:
     test_cmd = 'src/tools/perf/run_benchmark'

--- a/dashboard/dashboard/start_try_job_test.py
+++ b/dashboard/dashboard/start_try_job_test.py
@@ -154,11 +154,9 @@ config = {
 }
 
 On Windows:
-  - If you're calling a python script you will need to add "python" to
-the command:
 
 config = {
-  'command': 'python tools/perf/run_benchmark -v --browser=release kraken',
+  'command': 'tools/perf/run_benchmark -v --browser=release kraken',
   'good_revision': '185319',
   'bad_revision': '185364',
   'metric': 'Total/Total',
@@ -233,11 +231,9 @@ config = {
 }
 
 On Windows:
-  - If you're calling a python script you will need to add "python" to
-the command:
 
 config = {
-  'command': 'python tools/perf/run_benchmark -v --browser=release smoothness.key_mobile_sites',
+  'command': 'tools/perf/run_benchmark -v --browser=release smoothness.key_mobile_sites',
   'metric': 'mean_frame_time/mean_frame_time',
   'repeat_count': '20',
   'max_time_minutes': '20',


### PR DESCRIPTION
As flagged in bug 2283, I've removed "python" from being prepended to commands from bisect bot on Windows. Tests are still passing happily.