### PR TITLE
systrace: Force systrace to use adb from the devil

### DIFF
--- a/systrace/systrace/run_systrace.py
+++ b/systrace/systrace/run_systrace.py
@@ -34,6 +34,8 @@ _CATAPULT_DIR = os.path.join(
 _DEVIL_DIR = os.path.join(_CATAPULT_DIR, 'devil')
 if _DEVIL_DIR not in sys.path:
   sys.path.insert(0, _DEVIL_DIR)
+  # Force systrace to use adb from devil to avoid conflict with default adb
+  os.environ["PATH"] = _DEVIL_DIR + '/bin/deps/linux2/x86_64/bin/' + os.pathsep + os.environ["PATH"]
 if _SYSTRACE_DIR not in sys.path:
   sys.path.insert(0, _SYSTRACE_DIR)
 


### PR DESCRIPTION
run_systrace.py is slow if there's an adb in $PATH that's newer than the one
in devil.

First of all, run_systrace.py needs an adb in $PATH to begin with otherwise
it complaints. So I've had the adb from my android_sdk/platform-tools/ which
I use with my android devies in $PATH.

The issue happens when run_systrace.py initially starts to use the adb from
my $PATH but then code execution goes to devil.android device_utils, it tries
to use the adb from devil, this results in adb server being killed and restart.
Causing a slow down of around 10 seconds in every run.

To work around this, we have run_systrace.py start to use the adb from devil
so that the entire run uses just one version of adb (the one in devil).

Signed-off-by: Joel Fernandes <agnel.joel@gmail.com>