### PR TITLE
tracing: cpu: Use colors for different threads

### DIFF
--- a/tracing/tracing/model/cpu.html
+++ b/tracing/tracing/model/cpu.html
@@ -185,9 +185,10 @@ tr.exportTo('tr.model', function() {
       }
 
       var duration = end_timestamp - this.lastActiveTimestamp_;
+      var colorId = this.lastActiveName_ + '-' + this.lastActiveArgs_['tid']
       var slice = new tr.model.CpuSlice(
           '', this.lastActiveName_,
-          ColorScheme.getColorIdForGeneralPurposeString(this.lastActiveName_),
+          ColorScheme.getColorIdForGeneralPurposeString(colorId),
           this.lastActiveTimestamp_,
           this.lastActiveArgs_,
           duration);


### PR DESCRIPTION
Currently systrace displays CpuSlices for threads based on thread name thus
making slices of different threads use the same color. We use thread ID
information to have different threads in a process use different colors.

Following are some images from running rt-migrate-tests showing the different
threads, all the threads have the same name (rt-migrate-tests) but use
different colors thus allowing one to see them in different colors. kernelshark
already does this.

Before: http://imgur.com/a/eySbh
After : http://imgur.com/a/ej7Ob

Signed-off-by: Joel Fernandes <agnel.joel@gmail.com>