### PR TITLE
Add interactive mode which pauses before shutting down after tests.

### DIFF
--- a/telemetry/telemetry/internal/story_runner.py
+++ b/telemetry/telemetry/internal/story_runner.py
@@ -44,6 +44,9 @@ def AddCommandLineArgs(parser):
                    help='Maximum number of test failures before aborting '
                    'the run. Defaults to the number specified by the '
                    'PageTest.')
+  group.add_option('--interactive', dest='interactive', default=False,
+                   action='store_true', help='Let the user interact with '
+                   'the page after the test has run.')
   parser.add_option_group(group)
 
   # WPR options

--- a/telemetry/telemetry/page/shared_page_state.py
+++ b/telemetry/telemetry/page/shared_page_state.py
@@ -141,6 +141,8 @@ class SharedPageState(story.SharedState):
   def DidRunStory(self, results):
     if self._finder_options.profiler:
       self._StopProfiling(results)
+    if self._finder_options.interactive:
+      raw_input("Interacting... Press Enter to continue.")
     # We might hang while trying to close the connection, and need to guarantee
     # the page will get cleaned up to avoid future tests failing in weird ways.
     try:


### PR DESCRIPTION
Interactive mode used to be part of page_test but was removed to make
running tests consistent. I think we can safely re-add interactive mode
by pausing after running the story actions before shutting down. This is
a useful flag for easily debugging specific stories.

It was removed in https://codereview.chromium.org/1056213002/