### PR TITLE
Syntax updates for Polymer 2.0

### DIFF
--- a/tracing/tracing/ui/analysis/analysis_link.html
+++ b/tracing/tracing/ui/analysis/analysis_link.html
@@ -22,7 +22,7 @@ found in the LICENSE file.
       text-decoration: underline;
     }
     </style>
-    <a href="{{href}}" on-click="onClicked_" on-mouseenter="onMouseEnter_" on-mouseleave="onMouseLeave_"><content></content></a>
+    <a href="{{href}}" on-click="onClicked_" on-mouseenter="onMouseEnter_" on-mouseleave="onMouseLeave_"><slot></slot></a>
 
   </template>
 </dom-module>

--- a/tracing/tracing/ui/analysis/analysis_view.html
+++ b/tracing/tracing/ui/analysis/analysis_view.html
@@ -66,7 +66,7 @@ using custom elements specialized for different event types.
         height: 525px;
       }
     </style>
-    <content></content>
+    <slot></slot>
   </template>
 </dom-module>
 <script>

--- a/tracing/tracing/ui/analysis/single_object_snapshot_sub_view.html
+++ b/tracing/tracing/ui/analysis/single_object_snapshot_sub_view.html
@@ -43,7 +43,7 @@ found in the LICENSE file.
       vertical-align: top;
     }
     </style>
-    <content></content>
+    <slot></slot>
   </template>
 </dom-module>
 <script>

--- a/tracing/tracing/ui/base/dropdown.html
+++ b/tracing/tracing/ui/base/dropdown.html
@@ -11,24 +11,24 @@ found in the LICENSE file.
   <template>
     <style>
     button {
-      @apply(--dropdown-button);
+      @apply --dropdown-button;
     }
     button.open {
-      @apply(--dropdown-button-open);
+      @apply --dropdown-button-open;
     }
     dialog {
       position: absolute;
       margin: 0;
       padding: 1em;
       border: 1px solid darkgrey;
-      @apply(--dropdown-dialog);
+      @apply --dropdown-dialog;
     }
     </style>
 
     <button id="button" on-tap="open">[[label]]</button>
 
     <dialog id="dialog" on-tap="onDialogTap_" on-cancel="close">
-      <content></content>
+      <slot></slot>
     </dialog>
   </template>
 </dom-module>

--- a/tracing/tracing/ui/base/resize_sensor.html
+++ b/tracing/tracing/ui/base/resize_sensor.html
@@ -21,7 +21,7 @@ found in the LICENSE file.
       }
     </style>
     <div id="container">
-      <content></content>
+      <slot></slot>
     </div>
   </template>
 </dom-module>

--- a/tracing/tracing/ui/base/tab_view.html
+++ b/tracing/tracing/ui/base/tab_view.html
@@ -93,8 +93,8 @@ and limit users to having one option selected at a time.
       </template>
     </div>
     <div id='subView'></div>
-    <content>
-    </content>
+    <slot>
+    </slot>
   </template>
 </dom-module>
 <script>

--- a/tracing/tracing/ui/base/toolbar_button.html
+++ b/tracing/tracing/ui/base/toolbar_button.html
@@ -35,7 +35,7 @@ found in the LICENSE file.
     }
     </style>
     <div id="aligner">
-      <content></content>
+      <slot></slot>
     </div>
   </template>
 </dom-module>

--- a/tracing/tracing/ui/timeline_track_view.html
+++ b/tracing/tracing/ui/timeline_track_view.html
@@ -64,7 +64,7 @@ found in the LICENSE file.
       font-size: 8pt;
     }
     </style>
-    <content></content>
+    <slot></slot>
 
     <div id='drag_box'></div>
     <div id='hint_text'></div>

--- a/tracing/tracing/ui/timeline_view.html
+++ b/tracing/tracing/ui/timeline_view.html
@@ -136,7 +136,7 @@ found in the LICENSE file.
       </tr-ui-b-info-bar-group>
     </div>
     <middle-container>
-      <content></content>
+      <slot></slot>
 
       <tr-ui-side-panel-container id="side_panel_container">
       </tr-ui-side-panel-container>


### PR DESCRIPTION
Polymer 2.0 is prudction ready, and we advise all projects to begin migration. To aid in that migration, we're writing and applying some automated fixes for the mechanical parts of the upgrade.

The <content> element is deprecated, part of the Shadow DOM v0 API which has been supplanted by Shadow DOM v1's <slot> element. For very simple uses – like those in this PR – this change should be safe and will not require changes to the usage sites of your element. Therefor, these changes are backwards-compatible with Polymer 1.0 applications.

As <content> is the more powerful API, Polymer 1.0 supports both <content> and <slot> by converting <slot> back into <content> at runtime. Polymer 2.0 only supports <slot>. There will likely never be cross-browser native support for <content>, while Safari and Chrome already support <slot> natively.

This change also updates your usage of `@apply` to remove the parentheses. Like the other changes in this CL, these are backwards compatible with Polymer 1.0, and necessary for Polymer 2.0.