### PR TITLE
fixes #4125

### DIFF
--- a/systrace/profile_chrome/profiler.py
+++ b/systrace/profile_chrome/profiler.py
@@ -48,10 +48,12 @@ def _GetResults(trace_results, controller, output, compress, write_json,
     util.ArchiveData(trace_results, result)
   elif output:
     result = output
+    util.CreateDirectory(result)
     with open(result, 'wb') as f:
       f.write(trace_results[0].raw_data)
   else:
     result = trace_results[0].source_name
+    util.CreateDirectory(result)
     with open(result, 'wb') as f:
       f.write(trace_results[0].raw_data)
 

--- a/systrace/profile_chrome/util.py
+++ b/systrace/profile_chrome/util.py
@@ -33,3 +33,10 @@ def WriteDataToCompressedFile(data, output):
 
 def GetTraceTimestamp():
   return time.strftime('%Y-%m-%d-%H%M%S', time.localtime())
+
+def CreateDirectory(file_name):
+  # get absolute path of file
+  dir_name = os.path.dirname(os.path.abspath(file_name))
+  # create path if necessary
+  if not os.path.exists(dir_name):
+    os.makedirs(dir_name)


### PR DESCRIPTION
Create the directory, if it should not exist, when using a custom path to store in.

Also consider deep directory structures with several folders, that do not exist.