### PR TITLE
Add luci.catapult.ci bucket

### DIFF
--- a/cr-buildbucket.cfg
+++ b/cr-buildbucket.cfg
@@ -7,6 +7,14 @@
 # Please keep this list sorted by bucket name.
 
 buckets {
+  name: "luci.catapult.ci"
+  acls {
+    role: READER
+    group: "all"
+  }
+}
+
+buckets {
   name: "master.tryserver.client.catapult"
   acls {
     role: READER


### PR DESCRIPTION
Add an empty, dummy luci.catapult.ci bucket. Eventually catapult CI builds will
move to this bucket. In the meantime, the existing buildbot master is mapped
to this non-existing bucket and Milo is trying to query it.

Bug: 833420