### PR TITLE
Add flow support for ftrace

### DIFF
--- a/tracing/tracing/extras/importer/linux_perf/android_parser.html
+++ b/tracing/tracing/extras/importer/linux_perf/android_parser.html
@@ -33,6 +33,7 @@ tr.exportTo('tr.e.importer.linux_perf', function() {
 
     this.model_ = importer.model_;
     this.ppids_ = {};
+    this.openFlows_ = {};
   }
 
   function parseArgs(argsString) {
@@ -67,6 +68,7 @@ tr.exportTo('tr.e.importer.linux_perf', function() {
         this.openAsyncSlices = { };
       }
       this.openAsyncSlices[key] = slice;
+      return slice;
     },
 
     closeAsyncSlice(thread, category, name, cookie, ts, args) {
@@ -98,6 +100,30 @@ tr.exportTo('tr.e.importer.linux_perf', function() {
       slice.duration = ts - slice.start;
       slice.startThread.asyncSliceGroup.push(slice);
       delete this.openAsyncSlices[key];
+      return slice;
+    },
+
+    openFlow(slice, thread, category, name, cookie, ts, args) {
+      const key = category + ':' + name + ':' + cookie;
+
+      let flow = new tr.model.FlowEvent(category, cookie, name, 1, ts, args);
+      flow.startSlice = slice;
+
+      this.openFlows_[key] = flow;
+    },
+
+    closeFlow(slice, thread, category, name, cookie, ts) {
+      const key = category + ':' + name + ':' + cookie;
+
+      const flow = this.openFlows_[key];
+      if(!flow) {
+        // No open flows with this key
+        return;
+      }
+
+      flow.duration = ts - flow.start;
+      flow.endSlice = slice;
+      this.model_.flowEvents.push(flow);
     },
 
     traceMarkWriteAndroidEvent(eventName, cpuNumber, pid, ts,
@@ -218,6 +244,53 @@ tr.exportTo('tr.e.importer.linux_perf', function() {
 
           this.ppids_[pid] = ppid;
           this.closeAsyncSlice(thread, category, name, cookie, ts, args);
+
+          break;
+        }
+
+        case 's': {
+          // Flow event start
+          // Note: An flow may end on a different thread from the one
+          // that started it so this thread may not have been seen yet.
+          const ppid = parseInt(eventData[1]);
+
+          const name = eventData[2];
+          const cookie = eventData[3];
+          const args = parseArgs(eventData[4]);
+          let category = eventData[5];
+          if (category === undefined) category = 'android';
+
+          const thread = this.model_.getOrCreateProcess(ppid)
+              .getOrCreateThread(pid);
+          thread.name = eventBase.threadName;
+
+          this.ppids_[pid] = ppid;
+          let slice = this.closeAsyncSlice(thread, category, name, cookie, ts, args);
+          if(slice) {
+            this.openFlow(slice, thread, category, name, cookie, ts, args);
+          }
+
+          break;
+        }
+
+        case 'f': {
+          // Flow event end
+          const ppid = parseInt(eventData[1]);
+          const name = eventData[2];
+          const cookie = eventData[3];
+          const args = parseArgs(eventData[4]);
+          let category = eventData[5];
+          if (category === undefined) category = 'android';
+
+          const thread = this.model_.getOrCreateProcess(ppid)
+              .getOrCreateThread(pid);
+          thread.name = eventBase.threadName;
+
+          this.ppids_[pid] = ppid;
+          let slice = this.openAsyncSlice(thread, category, name, cookie, ts, args);
+          if(slice) {
+            this.closeFlow(slice, thread, category, name, cookie, ts);
+          }
 
           break;
         }

--- a/tracing/tracing/extras/importer/linux_perf/ftrace_importer.html
+++ b/tracing/tracing/extras/importer/linux_perf/ftrace_importer.html
@@ -793,7 +793,8 @@ tr.exportTo('tr.e.importer.linux_perf', function() {
         // Check if the event matches events traced by the Android framework
         const tag = eventBase.details.substring(0, 2);
         if (tag === 'B|' || tag === 'E' || tag === 'E|' || tag === 'X|' ||
-            tag === 'C|' || tag === 'S|' || tag === 'F|') {
+            tag === 'C|' || tag === 'S|' || tag === 'F|' || tag === 's|' ||
+            tag === 'f|' ) {
           eventBase.subEventName = 'android';
         } else {
           return false;


### PR DESCRIPTION
I'm not sure if I've done this right, but I wanted to trace the usage of a few of the file locks in my program, so I added flow tracing support to the ftrace viewer.

I read through the [trace even format specification](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.4qqub5rv9ybk) but it's not clear how that is associated with the format of ftrace markers, so I mostly copied the format from the async markers.

The format says that flow events should be associated with slices. I get weird rendering artifacts if they're not associated with async slices, so I add async slices when I add each flow event. I'm not sure if this is entirely right, but it seems easier for both the data association and the trace marker logging.